### PR TITLE
Update basic_env.md

### DIFF
--- a/docs/tutorial/deploy/basic_env.md
+++ b/docs/tutorial/deploy/basic_env.md
@@ -46,7 +46,7 @@ vim ipfile
 
 ```bash
 # -f 表示以文件为输入
-bash ./WeCross/build_wecross.sh -n payment -o routers-payment -f ipfile
+bash ./WeCross/build_wecross.sh -n payment -o routers-payment -f ../ipfile
 
 # 成功输出如下信息
 [INFO] Create routers-payment/127.0.0.1-8250-25500 successfully


### PR DESCRIPTION
create file "ipfile" in wecross-networks, but execute parameters "-f ipfile" of "build_wecross.sh".error will be reported, and the parameter should be modified to "-f ../ipfile" to be correct.